### PR TITLE
Workaround for file touch always reporting change

### DIFF
--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -13,9 +13,22 @@
     - filesystem-layout
     - php
 
-- name: Files Exist with Correct Permissions
+- name: Files Exist
+  copy:
+    content: ""
+    dest: "{{ item }}"
+    owner: "{{ php_user }}"
+    group: "{{ php_group }}"
+    mode: 0664
+    force: no
+  with_items:
+    - "{{ php_fpm_log_path }}"
+    - "{{ php_error_log_path }}"
+    - "{{ php_slow_log_path }}"
+
+- name: Files Have Correct Permissions
   file:
-    state: touch
+    state: file
     path: "{{ item }}"
     owner: "{{ php_user }}"
     group: "{{ php_group }}"


### PR DESCRIPTION
So there's this problem:
 - touch always changes the file, as it updates the timestamp (that's okay, we just don't need that for a logfile)
 - copy would overwrite the contents everytime so force=no
 - but with force=no copy would not check (and fix) the permissions of a file
 - so we better make the logfile creation in two phases: create if does not exist, and fix the ownership and permissions if required

This is not the best solution, as file state=present would be better, but as the github issues get closed with no solution just workarounds, we have to work-around. :)

Best regards,

Peter