### PR TITLE
Removed fluentd reference.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,20 +3,6 @@ dependencies:
   - role: telusdigital.apt-repository
     repository_key: "0x4f4ea0aae5267a6c"
     repository_url: "deb http://ppa.launchpad.net/ondrej/php5-5.6/ubuntu {{ ansible_distribution_release }} main"
-  # - role: telusdigital.fluentd
-  #   fluentd_config_name: php
-  #   fluentd_sources:
-  #     - path: "{{ php_fpm_log_path }}"
-  #       format: '/^\[(?<date_time>(?<date>[^ ]*) (?<time>[^]]*)[^]]*)\] (?<notice>\w+): (?<message>.*)/'
-  #       tag: reformed.elasticsearch.php.service
-  #     - path: "{{ php_error_log_path }}"
-  #       format: '/^(?<time>[^ ]+ [^ ]+ [^ ]+) \[(?<project>[^]]*)\] \[(?<session_id>[^]]*)\] \[(?<log_level>[^]]*)\] - (?<message>.*)/'
-  #       tag: reformed.elasticsearch.php.error
-  #     # - path: "{{ php_slow_log_path }}"
-  #     #   format: '/^.*/'
-  #     #   tag: php.slow
-  #   fluentd_plugins:
-  #     - elasticsearch
   - role: telusdigital.logrotate
     logrotate_name: php
     logrotate_notify_pidfile: "{{ php_fpm_pidfile_path }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -114,6 +114,7 @@
   sudo: yes
   ignore_errors: yes
   shell: pecl install channel://pecl.php.net/libsodium-1.0.2
+  failed_when: "not (('already installed' in pecl_result.stdout) or ('install ok:' in pecl_result.stdout))"
   notify:
     - Reload Service | nginx
     - service | php5-fpm | reloaded


### PR DESCRIPTION
We no longer require fluentd configs in our roles, at present we utilize logstash. But we may want to revisit fluentd.