### PR TITLE
fixing libsodium issues

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ php_composer: no
 php_documentor: no
 php_phpunit: no
 php_sodium: no
+php_sodium_version: 0.1.1
 
 php_documentor_validate_certs: yes
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -111,7 +111,7 @@
     - sodium
 
 - name: Sodium | Install PHP extension
-  sudo: yes
+  become: yes
   ignore_errors: yes
   shell: "pecl install channel://pecl.php.net/libsodium-{{ php_sodium_version }}"
   notify:
@@ -139,7 +139,7 @@
     - sodium
 
 - name: "Sodium | php5enmod libsodium"
-  sudo: yes
+  become: yes
   shell: "php5enmod libsodium"
   when: php_sodium
   tags:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 - name: Install Packages | apt
   apt:
     state: latest
-    pkg: "{{ item }}"
+    name: "{{ item }}"
   with_items:
     - "{{ 'php5-fpm' if php_fpm else 'php5-cli' }}"
   tags:
@@ -12,7 +12,7 @@
 - name: Install Packages | apt
   apt:
     state: latest
-    pkg: "{{ item }}"
+    name: "{{ item }}"
   with_items: php_modules
   tags:
     - software-installation
@@ -73,11 +73,20 @@
 - name: Sodium | Install php5-dev | apt
   apt:
     state: latest
-    pkg: php5-dev
+    name: php5-dev
   when: php_sodium
   tags:
     - software-installation
     - using-apt
+    - sodium
+
+- name: Purge Libsodium
+  apt:
+    state: absent
+    purge: yes
+    name: libsodium13
+  when: php_sodium
+  tags:
     - sodium
 
 - name: Sodium | Git
@@ -104,7 +113,7 @@
 - name: Sodium | Install PHP extension
   sudo: yes
   ignore_errors: yes
-  shell: pecl install channel://pecl.php.net/libsodium-1.0.2
+  shell: "pecl install channel://pecl.php.net/libsodium-{{ php_sodium_version }}"
   notify:
     - Reload Service | nginx
     - service | php5-fpm | reloaded

--- a/test/integration/default/serverspec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/localhost/default_spec.rb
@@ -6,25 +6,7 @@ describe 'ansible-php::default' do
     it { should be_installed.by('apt') }
   end
 
-  describe service('php5-fpm') do
-    it { should be_running }
-  end
-
   describe command('php -i') do
     its(:stdout) { should_not match /PHP Warning/ }
-  end
-
-  describe 'PHP Config' do
-    context php_config('display_errors') do
-      its(:value) { should eq 'On' }
-    end
-
-    context php_config('max_execution_time') do
-      its(:value) { should eq 30 }
-    end
-
-    context php_config('session.cookie_secure') do
-      its(:value) { should eq 'Off' }
-    end
   end
 end

--- a/test/integration/default/serverspec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/localhost/default_spec.rb
@@ -5,4 +5,26 @@ describe 'ansible-php::default' do
   describe package('php5-fpm') do
     it { should be_installed.by('apt') }
   end
+
+  describe service('php5-fpm') do
+    it { should be_running }
+  end
+
+  describe command('php -i') do
+    its(:stdout) { should_not match /PHP Warning/ }
+  end
+
+  describe 'PHP Config' do
+    context php_config('display_errors') do
+      its(:value) { should eq 'On' }
+    end
+
+    context php_config('max_execution_time') do
+      its(:value) { should eq 30 }
+    end
+
+    context php_config('session.cookie_secure') do
+      its(:value) { should eq 'Off' }
+    end
+  end
 end


### PR DESCRIPTION
A project was having issues with this libsodium install today. They were getting the error message
```
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php5/20131226/libsodium.so' - /usr/lib/php5/20131226/libsodium.so: undefined symbol: sodium_compare in Unknown on line 0
```

This was because libsodium was already getting installed via `apt-get install libsodium13`.